### PR TITLE
remove quote validation from jscsrc

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -14,7 +14,7 @@
     "requireCamelCaseOrUpperCaseIdentifiers": true,
 
     
-    "validateQuoteMarks": "'",
+    
 
     "disallowMultipleLineStrings": true,
     "disallowMixedSpacesAndTabs": true,


### PR DESCRIPTION
Allow to use single or double quotes
